### PR TITLE
Fixed Tutorial X Button

### DIFF
--- a/docs/scripts/game.js
+++ b/docs/scripts/game.js
@@ -613,7 +613,7 @@ game.tutorialOverlay = {
             // Refresh the timeout timer
             game.timeoutOverlay.refreshTimer();
             // Display keypads
-            game.playLetterSpaces.showLetters();
+            game.playLetterSpaces.adjustStyle();
             game.inputKeypad.adjustStyle();
             // Redraw all elements
             game.drawOnce();


### PR DESCRIPTION
Bug: When opening the tutorial overlay from the play scene using the snackbar, pressing the 'X' close button would populate all the letters for the current word.

game.js:
- Changed the tutorial overlay's startGame function when opened through the snackbar
    - Changed the game.playLetterSpaces object from calling the showLetters function to the adjustStyle function